### PR TITLE
Adding API key masking test

### DIFF
--- a/pkg/adaptor/hypervisor/ibmcloud/types_test.go
+++ b/pkg/adaptor/hypervisor/ibmcloud/types_test.go
@@ -1,0 +1,28 @@
+package ibmcloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMasking(t *testing.T) {
+	apiKey := "abcdefg"
+	zoneName := "eu-gb"
+	cloudCfg := Config{
+		ApiKey:   apiKey,
+		ZoneName: zoneName,
+	}
+	checkLine := func(verb string) {
+		logline := fmt.Sprintf(verb, &cloudCfg)
+		if strings.Contains(logline, apiKey) {
+			t.Errorf("For verb %s: %s contains the api key: %s", verb, logline, apiKey)
+		}
+		if !strings.Contains(logline, zoneName) {
+			t.Errorf("For verb %s: %s doesn't contain the zone name: %s", verb, logline, zoneName)
+		}
+	}
+	checkLine("%v")
+	checkLine("%s")
+	checkLine("%q")
+}


### PR DESCRIPTION
Hi Dave,

Just created a quick test to see if your changes worked as I suspected. 

This is the result of running these tests

```
--- FAIL: TestMasking (0.00s)
    types_test.go:22: For verb %s: ******** doesn't contain the zone name: eu-gb
    types_test.go:22: For verb %q: "********" doesn't contain the zone name: eu-gb
```

Is it the intention that when using the `%s` verb that it will just return the keymask?
